### PR TITLE
Add optional sentryHost to Sentry Adapter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ To run all unit tests, use the following Docker command:
 docker run --rm -e TEST_RAYGUN_KEY=KKKK -e TEST_APPSIGNAL_KEY=XXXX -e TEST_SENTRY_KEY=YYYY -e TEST_SENTRY_PROJECT_ID=ZZZZ -v $(pwd):$(pwd):rw -w $(pwd) php:8.0-cli-alpine sh -c "vendor/bin/phpunit --configuration phpunit.xml tests"
 ```
 
-> Make sure to replace `TEST_SENTRY_KEY` and `TEST_SENTRY_PROJECT_ID` environment variables value with actual keys from Sentry. If your Sentry DSN is `https://something@otherthing.ingest.sentry.io/anything`, then `TEST_SENTRY_KEY=something` and `TEST_SENTRY_PROJECT_ID=anything`
+> Make sure to replace `TEST_SENTRY_KEY` and `TEST_SENTRY_PROJECT_ID` environment variables value with actual keys from Sentry. If your Sentry DSN is `https://something@otherthing.ingest.sentry.io/anything`, then `TEST_SENTRY_KEY=something` and `TEST_SENTRY_PROJECT_ID=anything`.
+  Optionally `TEST_SENTRY_HOST` can be added to specify a self-hosted Sentry instance. 
 
 > Make sure to replace `TEST_APPSIGNAL_KEY` with key found in Appsignal -> Project -> App Settings -> Push & deploy -> Push Key
 

--- a/src/Logger/Adapter/Sentry.php
+++ b/src/Logger/Adapter/Sentry.php
@@ -23,6 +23,12 @@ class Sentry extends Adapter
     protected string $projectId;
 
     /**
+     * @var string (optional, the host where Sentry is reachable, in case of self-hosted Sentry could
+     *              look like 'https://sentry.mycompany.com'. defaults to 'https://sentry.io')
+     */
+    protected string $sentryHost;
+
+    /**
      * Return unique adapter name
      *
      * @return string
@@ -82,7 +88,7 @@ class Sentry extends Adapter
 
         // define options
         $optArray = array(
-            CURLOPT_URL => 'https://sentry.io/api/' . $this->projectId . '/store/',
+            CURLOPT_URL => $this->sentryHost . '/api/' . $this->projectId . '/store/',
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_POST => true,
             CURLOPT_POSTFIELDS => \json_encode($requestBody),
@@ -116,6 +122,11 @@ class Sentry extends Adapter
         $configChunks = \explode(";", $configKey);
         $this->sentryKey = $configChunks[0];
         $this->projectId = $configChunks[1];
+        $this->sentryHost = 'https://sentry.io';
+
+        if(count($configChunks) > 2 && !empty($configChunks[2])) {
+            $this->sentryHost = $configChunks[2];
+        }
     }
 
 

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -165,7 +165,7 @@ class LoggerTest extends TestCase
         $log->addExtra('isExpected', true);
 
         // Test Sentry
-        $adapter = new Sentry(\getenv("TEST_SENTRY_KEY") . ';' . \getenv("TEST_SENTRY_PROJECT_ID"));
+        $adapter = new Sentry(\getenv("TEST_SENTRY_KEY") . ';' . \getenv("TEST_SENTRY_PROJECT_ID") . ';' . \getenv("TEST_SENTRY_HOST"));
         $logger = new Logger($adapter);
         $response = $logger->addLog($log);
         // self::assertEquals(200, $response);


### PR DESCRIPTION
As discussed in #6 this adds support for self-hosted Sentry instances by allowing to set a custom url. Specifying the url is optional an can be omitted.

An Example using this functionality would set the url as the third part of the `$configKey`: `<sentryKey>;<projectId>;<sentryHost>`.

I'm not sure how to Unit-Test this functionality, so any guidance would be appreciated.