### PR TITLE
Fix: Sentry trace warning

### DIFF
--- a/src/Logger/Adapter/Sentry.php
+++ b/src/Logger/Adapter/Sentry.php
@@ -116,7 +116,7 @@ class Sentry extends Adapter
                 }
                 \array_push($stackFrames, [
                     'filename' => $trace['file'] ?? '',
-                    'lineno' => $trace['line'] ?? '',
+                    'lineno' => $trace['line'] ?? 0,
                     'function' => $trace['function'] ?? '',
                 ]);
             }


### PR DESCRIPTION
Error from deletes worker results in log with following warning on Sentry:

![CleanShot 2023-11-22 at 15 34 22@2x](https://github.com/utopia-php/logger/assets/19310830/24fe7f01-7d77-46ef-a900-ada62c21ec64)

Inspecting the trace, I noticed:

```
appwrite-worker-deletes  |   [1]=>
appwrite-worker-deletes  |   array(3) {
appwrite-worker-deletes  |     ["filename"]=>
appwrite-worker-deletes  |     string(0) ""
appwrite-worker-deletes  |     ["lineno"]=>
appwrite-worker-deletes  |     string(0) ""
appwrite-worker-deletes  |     ["function"]=>
appwrite-worker-deletes  |     string(22) "Utopia\Queue\{closure}"
appwrite-worker-deletes  |   }
```

This PR replaces empty string on line number with number 0. That results in error going away.

- [x] Manual QA:

![CleanShot 2023-11-22 at 15 35 28@2x](https://github.com/utopia-php/logger/assets/19310830/176925de-3b86-4075-b9e1-e67fe8507e0c)
