### PR TITLE
Add sample function to logger

### DIFF
--- a/src/Logger/Logger.php
+++ b/src/Logger/Logger.php
@@ -16,6 +16,11 @@ class Logger
     ];
 
     /**
+     * @var float|null
+     */
+    protected $samplePercent = null;
+
+    /**
      * @var Adapter
      */
     protected Adapter $adapter;
@@ -51,6 +56,12 @@ class Logger
             throw new Exception('Log is not ready to be pushed.');
         }
 
+        if (!is_null($this->samplePercent)) {
+            if (rand(0, 100) <= $this->samplePercent) {
+                return 0;
+            }
+        }
+
         if ($this->adapter->validate($log)) {
             // Push log
             return $this->adapter->push($log);
@@ -84,5 +95,14 @@ class Logger
         }
 
         return false;
+    }
+
+    /**
+     * Return only a sample of the logs from this logger
+     * 
+     * @param float $sample Total percentage of issues to use with 100% being 1
+     */
+    public function sample(float $sample) {
+        $this->samplePercent = $sample * 100;
     }
 }

--- a/src/Logger/Logger.php
+++ b/src/Logger/Logger.php
@@ -101,6 +101,7 @@ class Logger
      * Return only a sample of the logs from this logger
      * 
      * @param float $sample Total percentage of issues to use with 100% being 1
+     * @return void
      */
     public function sample(float $sample) {
         $this->samplePercent = $sample * 100;

--- a/tests/e2e/Adapter/AppSignalTest.php
+++ b/tests/e2e/Adapter/AppSignalTest.php
@@ -7,6 +7,8 @@ use Utopia\Tests\E2E\AdapterBase;
 
 class AppSignalTest extends AdapterBase
 {
+    protected int $expected = 204;
+
     protected function setUp(): void
     {
         parent::setUp();

--- a/tests/e2e/AdapterBase.php
+++ b/tests/e2e/AdapterBase.php
@@ -58,4 +58,23 @@ abstract class AdapterBase extends TestCase
         $response = $logger->addLog($this->log);
         $this->assertEquals($this->expected, $response);
     }
+
+    /**
+     * @throws \Throwable
+     */
+    public function testSampler(): void
+    {
+        if (empty($this->log) || empty($this->adapter)) {
+            throw new \Exception('Log or adapter not set');
+        }
+        $logger = new Logger($this->adapter);
+
+        $results = [];
+
+        for ($x = 0; $x <= 10; $x++) {
+            $results[] = $logger->addLog($this->log);
+        }
+
+        $this->assertTrue(in_array(0, $results));
+    }
 }


### PR DESCRIPTION
This PR introduces a new function to the `Logger` object called `sample` which accepts a float value.

This PR also includes tests as well as a small fix to the AppSignal tests where we expect 200 but receive 204.