### PR TITLE
fix: dont throw on log push failure

### DIFF
--- a/.github/workflows/code-ql-analysis.yml
+++ b/.github/workflows/code-ql-analysis.yml
@@ -16,5 +16,5 @@ jobs:
 
     - name: Run CodeQL
       run: |
-        docker run --rm -v $PWD:/app composer sh -c \
+        docker run --rm -v $PWD:/app composer:2.6 sh -c \
         "composer install --profile --ignore-platform-reqs && composer check"

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -16,5 +16,5 @@ jobs:
 
       - name: Run Linter
         run: |
-          docker run --rm -v $PWD:/app composer sh -c \
+          docker run --rm -v $PWD:/app composer:2.6 sh -c \
           "composer install --profile --ignore-platform-reqs && composer lint"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.idea/
 .env
 .phpunit.result.cache
+.DS_Store

--- a/composer.lock
+++ b/composer.lock
@@ -478,12 +478,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "0dfb69d79d0964b8a80bfa92c07f50e3e8d73542"
+                "reference": "acc12399c90611e3cb478d0ec72f2c2ebbc429d1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0dfb69d79d0964b8a80bfa92c07f50e3e8d73542",
-                "reference": "0dfb69d79d0964b8a80bfa92c07f50e3e8d73542",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/acc12399c90611e3cb478d0ec72f2c2ebbc429d1",
+                "reference": "acc12399c90611e3cb478d0ec72f2c2ebbc429d1",
                 "shasum": ""
             },
             "require": {
@@ -541,7 +541,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-20T19:34:15+00:00"
+            "time": "2024-09-30T20:32:32+00:00"
         },
         {
             "name": "felixfbecker/advanced-json-rpc",
@@ -641,7 +641,7 @@
             ],
             "support": {
                 "issues": "https://github.com/felixfbecker/php-language-server-protocol/issues",
-                "source": "https://github.com/felixfbecker/php-language-server-protocol/tree/master"
+                "source": "https://github.com/felixfbecker/php-language-server-protocol/tree/v1.5.3"
             },
             "time": "2024-04-30T00:40:11+00:00"
         },
@@ -829,12 +829,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "0ed4c8949a32986043e977dbe14776c14d644c45"
+                "reference": "715f4d25e225bc47b293a8b997fe6ce99bf987d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/0ed4c8949a32986043e977dbe14776c14d644c45",
-                "reference": "0ed4c8949a32986043e977dbe14776c14d644c45",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/715f4d25e225bc47b293a8b997fe6ce99bf987d2",
+                "reference": "715f4d25e225bc47b293a8b997fe6ce99bf987d2",
                 "shasum": ""
             },
             "require": {
@@ -843,7 +843,7 @@
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -877,7 +877,7 @@
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
                 "source": "https://github.com/nikic/PHP-Parser/tree/4.x"
             },
-            "time": "2024-09-17T19:36:00+00:00"
+            "time": "2024-09-29T15:01:53+00:00"
         },
         {
             "name": "openlss/lib-array2xml",
@@ -1230,16 +1230,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.30.1",
+            "version": "1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "51b95ec8670af41009e2b2b56873bad96682413e"
+                "reference": "6ca22b154efdd9e3c68c56f5d94670920a1c19a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/51b95ec8670af41009e2b2b56873bad96682413e",
-                "reference": "51b95ec8670af41009e2b2b56873bad96682413e",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/6ca22b154efdd9e3c68c56f5d94670920a1c19a4",
+                "reference": "6ca22b154efdd9e3c68c56f5d94670920a1c19a4",
                 "shasum": ""
             },
             "require": {
@@ -1271,9 +1271,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.30.1"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.32.0"
             },
-            "time": "2024-09-07T20:13:05+00:00"
+            "time": "2024-09-26T07:23:32+00:00"
         },
         {
             "name": "phpstan/phpstan",
@@ -1659,12 +1659,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "de6abf3b6f8dd955fac3caad3af7a9504e8c2ffa"
+                "reference": "857d98630470c48a353f673060dec98e8c0686b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/de6abf3b6f8dd955fac3caad3af7a9504e8c2ffa",
-                "reference": "de6abf3b6f8dd955fac3caad3af7a9504e8c2ffa",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/857d98630470c48a353f673060dec98e8c0686b2",
+                "reference": "857d98630470c48a353f673060dec98e8c0686b2",
                 "shasum": ""
             },
             "require": {
@@ -1754,7 +1754,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-19T10:50:18+00:00"
+            "time": "2024-10-08T05:58:25+00:00"
         },
         {
             "name": "psr/container",
@@ -2830,12 +2830,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "5b5a0aa66e3296e303e22490f90f521551835a83"
+                "reference": "108d436c2af470858bdaba3257baab3a74172017"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/5b5a0aa66e3296e303e22490f90f521551835a83",
-                "reference": "5b5a0aa66e3296e303e22490f90f521551835a83",
+                "url": "https://api.github.com/repos/symfony/console/zipball/108d436c2af470858bdaba3257baab3a74172017",
+                "reference": "108d436c2af470858bdaba3257baab3a74172017",
                 "shasum": ""
             },
             "require": {
@@ -2921,7 +2921,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-20T07:56:40+00:00"
+            "time": "2024-10-08T07:27:17+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -3561,12 +3561,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "f8a1ccebd0997e16112dfecfd74220b78e5b284b"
+                "reference": "38371c60c71c72b3d64d8d76f6b1bb81a2cc3627"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/f8a1ccebd0997e16112dfecfd74220b78e5b284b",
-                "reference": "f8a1ccebd0997e16112dfecfd74220b78e5b284b",
+                "url": "https://api.github.com/repos/symfony/string/zipball/38371c60c71c72b3d64d8d76f6b1bb81a2cc3627",
+                "reference": "38371c60c71c72b3d64d8d76f6b1bb81a2cc3627",
                 "shasum": ""
             },
             "require": {
@@ -3639,7 +3639,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-20T08:15:52+00:00"
+            "time": "2024-09-25T14:18:03+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/src/Logger/Adapter/AppSignal.php
+++ b/src/Logger/Adapter/AppSignal.php
@@ -122,17 +122,20 @@ class AppSignal extends Adapter
         \curl_setopt_array($ch, $optArray);
 
         // execute request and get response
-        $result = \curl_exec($ch);
-        $response = \curl_getinfo($ch, \CURLINFO_HTTP_CODE);
-        $error = \curl_error($ch);
-
-        if ($response >= 400 || $response === 0) {
-            error_log("Log could not be pushed with status code {$response}: {$result} ({$error})");
-        }
-
+        $response = curl_exec($ch);
+        $httpCode = curl_getinfo($ch, \CURLINFO_HTTP_CODE);
+        $curlError = \curl_error($ch);
         \curl_close($ch);
 
-        return $response;
+        if ($curlError !== CURLE_OK) {
+            error_log("AppSignal push failed with curl error ({$curlError}): {$response}");
+            return 500;
+        }
+    
+        if ($httpCode >= 400 || $httpCode === 0) {
+            error_log("AppSignal push failed with status code {$httpCode}: {$curlError} ({$response})");
+            return $httpCode ?: 500;
+        }
     }
 
     public function getSupportedTypes(): array

--- a/src/Logger/Adapter/AppSignal.php
+++ b/src/Logger/Adapter/AppSignal.php
@@ -2,7 +2,6 @@
 
 namespace Utopia\Logger\Adapter;
 
-use Exception;
 use Utopia\Logger\Adapter;
 use Utopia\Logger\Log;
 use Utopia\Logger\Logger;

--- a/src/Logger/Adapter/AppSignal.php
+++ b/src/Logger/Adapter/AppSignal.php
@@ -129,13 +129,17 @@ class AppSignal extends Adapter
 
         if ($curlError !== CURLE_OK) {
             error_log("AppSignal push failed with curl error ({$curlError}): {$response}");
+
             return 500;
         }
-    
+
         if ($httpCode >= 400 || $httpCode === 0) {
             error_log("AppSignal push failed with status code {$httpCode}: {$curlError} ({$response})");
+
             return $httpCode ?: 500;
         }
+
+        return $httpCode;
     }
 
     public function getSupportedTypes(): array

--- a/src/Logger/Adapter/AppSignal.php
+++ b/src/Logger/Adapter/AppSignal.php
@@ -124,19 +124,17 @@ class AppSignal extends Adapter
         // execute request and get response
         $response = curl_exec($ch);
         $httpCode = curl_getinfo($ch, \CURLINFO_HTTP_CODE);
-        $curlError = \curl_error($ch);
+        $curlError = \curl_errno($ch);
         \curl_close($ch);
 
-        if ($curlError !== CURLE_OK) {
+        if ($curlError !== CURLE_OK || $httpCode === 0) {
             error_log("AppSignal push failed with curl error ({$curlError}): {$response}");
 
             return 500;
         }
 
-        if ($httpCode >= 400 || $httpCode === 0) {
+        if ($httpCode >= 400) {
             error_log("AppSignal push failed with status code {$httpCode}: {$curlError} ({$response})");
-
-            return $httpCode ?: 500;
         }
 
         return $httpCode;

--- a/src/Logger/Adapter/AppSignal.php
+++ b/src/Logger/Adapter/AppSignal.php
@@ -42,8 +42,6 @@ class AppSignal extends Adapter
      *
      * @param  Log  $log
      * @return int
-     *
-     * @throws Exception
      */
     public function push(Log $log): int
     {
@@ -130,7 +128,7 @@ class AppSignal extends Adapter
         $error = \curl_error($ch);
 
         if ($response >= 400 || $response === 0) {
-            throw new Exception("Log could not be pushed with status code {$response}: {$result} ({$error})");
+            error_log("Log could not be pushed with status code {$response}: {$result} ({$error})");
         }
 
         \curl_close($ch);

--- a/src/Logger/Adapter/LogOwl.php
+++ b/src/Logger/Adapter/LogOwl.php
@@ -141,17 +141,20 @@ class LogOwl extends Adapter
         \curl_setopt_array($ch, $optArray);
 
         // execute request and get response
-        $result = curl_exec($ch);
-        $response = curl_getinfo($ch, \CURLINFO_HTTP_CODE);
-        $error = \curl_error($ch);
-
-        if ($response >= 400 || $response === 0) {
-            error_log("Log could not be pushed with status code {$response}: {$result} ({$error})");
-        }
-
+        $response = curl_exec($ch);
+        $httpCode = curl_getinfo($ch, \CURLINFO_HTTP_CODE);
+        $curlError = \curl_error($ch);
         \curl_close($ch);
 
-        return $response;
+        if ($curlError !== CURLE_OK) {
+            error_log("LogOwl push failed with curl error ({$curlError}): {$response}");
+            return 500;
+        }
+    
+        if ($httpCode >= 400 || $httpCode === 0) {
+            error_log("LogOwl push failed with status code {$httpCode}: {$curlError} ({$response})");
+            return $httpCode ?: 500;
+        }
     }
 
     public function getSupportedTypes(): array

--- a/src/Logger/Adapter/LogOwl.php
+++ b/src/Logger/Adapter/LogOwl.php
@@ -2,7 +2,6 @@
 
 namespace Utopia\Logger\Adapter;
 
-use Exception;
 use Utopia\Logger\Adapter;
 use Utopia\Logger\Log;
 use Utopia\Logger\Logger;

--- a/src/Logger/Adapter/LogOwl.php
+++ b/src/Logger/Adapter/LogOwl.php
@@ -141,7 +141,6 @@ class LogOwl extends Adapter
         \curl_setopt_array($ch, $optArray);
 
         // execute request and get response
-        // execute request and get response
         $response = curl_exec($ch);
         $httpCode = curl_getinfo($ch, \CURLINFO_HTTP_CODE);
         $curlError = \curl_errno($ch);

--- a/src/Logger/Adapter/LogOwl.php
+++ b/src/Logger/Adapter/LogOwl.php
@@ -141,21 +141,20 @@ class LogOwl extends Adapter
         \curl_setopt_array($ch, $optArray);
 
         // execute request and get response
+        // execute request and get response
         $response = curl_exec($ch);
         $httpCode = curl_getinfo($ch, \CURLINFO_HTTP_CODE);
-        $curlError = \curl_error($ch);
+        $curlError = \curl_errno($ch);
         \curl_close($ch);
 
-        if ($curlError !== CURLE_OK) {
+        if ($curlError !== CURLE_OK || $httpCode === 0) {
             error_log("LogOwl push failed with curl error ({$curlError}): {$response}");
 
             return 500;
         }
 
-        if ($httpCode >= 400 || $httpCode === 0) {
+        if ($httpCode >= 400) {
             error_log("LogOwl push failed with status code {$httpCode}: {$curlError} ({$response})");
-
-            return $httpCode ?: 500;
         }
 
         return $httpCode;

--- a/src/Logger/Adapter/LogOwl.php
+++ b/src/Logger/Adapter/LogOwl.php
@@ -75,8 +75,6 @@ class LogOwl extends Adapter
      *
      * @param  Log  $log
      * @return int
-     *
-     * @throws Exception
      */
     public function push(Log $log): int
     {
@@ -149,7 +147,7 @@ class LogOwl extends Adapter
         $error = \curl_error($ch);
 
         if ($response >= 400 || $response === 0) {
-            throw new Exception("Log could not be pushed with status code {$response}: {$result} ({$error})");
+            error_log("Log could not be pushed with status code {$response}: {$result} ({$error})");
         }
 
         \curl_close($ch);

--- a/src/Logger/Adapter/LogOwl.php
+++ b/src/Logger/Adapter/LogOwl.php
@@ -148,13 +148,17 @@ class LogOwl extends Adapter
 
         if ($curlError !== CURLE_OK) {
             error_log("LogOwl push failed with curl error ({$curlError}): {$response}");
+
             return 500;
         }
-    
+
         if ($httpCode >= 400 || $httpCode === 0) {
             error_log("LogOwl push failed with status code {$httpCode}: {$curlError} ({$response})");
+
             return $httpCode ?: 500;
         }
+
+        return $httpCode;
     }
 
     public function getSupportedTypes(): array

--- a/src/Logger/Adapter/Raygun.php
+++ b/src/Logger/Adapter/Raygun.php
@@ -107,17 +107,20 @@ class Raygun extends Adapter
         \curl_setopt_array($ch, $optArray);
 
         // execute request and get response
-        $result = \curl_exec($ch);
-        $response = \curl_getinfo($ch, \CURLINFO_HTTP_CODE);
-        $error = \curl_error($ch);
-
-        if ($response >= 400 || $response === 0) {
-            error_log("Log could not be pushed with status code {$response}: {$result} ({$error})");
-        }
-
+        $response = curl_exec($ch);
+        $httpCode = curl_getinfo($ch, \CURLINFO_HTTP_CODE);
+        $curlError = \curl_error($ch);
         \curl_close($ch);
 
-        return $response;
+        if ($curlError !== CURLE_OK) {
+            error_log("Raygun push failed with curl error ({$curlError}): {$response}");
+            return 500;
+        }
+    
+        if ($httpCode >= 400 || $httpCode === 0) {
+            error_log("Raygun push failed with status code {$httpCode}: {$curlError} ({$response})");
+            return $httpCode ?: 500;
+        }
     }
 
     public function getSupportedTypes(): array

--- a/src/Logger/Adapter/Raygun.php
+++ b/src/Logger/Adapter/Raygun.php
@@ -2,7 +2,6 @@
 
 namespace Utopia\Logger\Adapter;
 
-use Exception;
 use Utopia\Logger\Adapter;
 use Utopia\Logger\Log;
 use Utopia\Logger\Logger;

--- a/src/Logger/Adapter/Raygun.php
+++ b/src/Logger/Adapter/Raygun.php
@@ -109,19 +109,17 @@ class Raygun extends Adapter
         // execute request and get response
         $response = curl_exec($ch);
         $httpCode = curl_getinfo($ch, \CURLINFO_HTTP_CODE);
-        $curlError = \curl_error($ch);
+        $curlError = \curl_errno($ch);
         \curl_close($ch);
 
-        if ($curlError !== CURLE_OK) {
+        if ($curlError !== CURLE_OK || $httpCode === 0) {
             error_log("Raygun push failed with curl error ({$curlError}): {$response}");
 
             return 500;
         }
 
-        if ($httpCode >= 400 || $httpCode === 0) {
+        if ($httpCode >= 400) {
             error_log("Raygun push failed with status code {$httpCode}: {$curlError} ({$response})");
-
-            return $httpCode ?: 500;
         }
 
         return $httpCode;

--- a/src/Logger/Adapter/Raygun.php
+++ b/src/Logger/Adapter/Raygun.php
@@ -114,13 +114,17 @@ class Raygun extends Adapter
 
         if ($curlError !== CURLE_OK) {
             error_log("Raygun push failed with curl error ({$curlError}): {$response}");
+
             return 500;
         }
-    
+
         if ($httpCode >= 400 || $httpCode === 0) {
             error_log("Raygun push failed with status code {$httpCode}: {$curlError} ({$response})");
+
             return $httpCode ?: 500;
         }
+
+        return $httpCode;
     }
 
     public function getSupportedTypes(): array

--- a/src/Logger/Adapter/Raygun.php
+++ b/src/Logger/Adapter/Raygun.php
@@ -42,8 +42,6 @@ class Raygun extends Adapter
      *
      * @param  Log  $log
      * @return int
-     *
-     * @throws Exception
      */
     public function push(Log $log): int
     {
@@ -115,7 +113,7 @@ class Raygun extends Adapter
         $error = \curl_error($ch);
 
         if ($response >= 400 || $response === 0) {
-            throw new Exception("Log could not be pushed with status code {$response}: {$result} ({$error})");
+            error_log("Log could not be pushed with status code {$response}: {$result} ({$error})");
         }
 
         \curl_close($ch);

--- a/src/Logger/Adapter/Sentry.php
+++ b/src/Logger/Adapter/Sentry.php
@@ -156,13 +156,17 @@ class Sentry extends Adapter
 
         if ($curlError !== CURLE_OK) {
             error_log("Sentry push failed with curl error ({$curlError}): {$response}");
+
             return 500;
         }
-    
+
         if ($httpCode >= 400 || $httpCode === 0) {
             error_log("Sentry push failed with status code {$httpCode}: {$curlError} ({$response})");
+
             return $httpCode ?: 500;
         }
+
+        return $httpCode;
     }
 
     public function getSupportedTypes(): array

--- a/src/Logger/Adapter/Sentry.php
+++ b/src/Logger/Adapter/Sentry.php
@@ -151,19 +151,17 @@ class Sentry extends Adapter
         // execute request and get response
         $response = curl_exec($ch);
         $httpCode = curl_getinfo($ch, \CURLINFO_HTTP_CODE);
-        $curlError = \curl_error($ch);
+        $curlError = \curl_errno($ch);
         \curl_close($ch);
 
-        if ($curlError !== CURLE_OK) {
+        if ($curlError !== CURLE_OK || $httpCode === 0) {
             error_log("Sentry push failed with curl error ({$curlError}): {$response}");
 
             return 500;
         }
 
-        if ($httpCode >= 400 || $httpCode === 0) {
+        if ($httpCode >= 400) {
             error_log("Sentry push failed with status code {$httpCode}: {$curlError} ({$response})");
-
-            return $httpCode ?: 500;
         }
 
         return $httpCode;

--- a/src/Logger/Adapter/Sentry.php
+++ b/src/Logger/Adapter/Sentry.php
@@ -149,17 +149,20 @@ class Sentry extends Adapter
         \curl_setopt_array($ch, $optArray);
 
         // execute request and get response
-        $result = curl_exec($ch);
-        $response = curl_getinfo($ch, \CURLINFO_HTTP_CODE);
-        $error = \curl_error($ch);
-
-        if ($response >= 400 || $response === 0) {
-            error_log("Log could not be pushed with status code {$response}: {$result} ({$error})");
-        }
-
+        $response = curl_exec($ch);
+        $httpCode = curl_getinfo($ch, \CURLINFO_HTTP_CODE);
+        $curlError = \curl_error($ch);
         \curl_close($ch);
 
-        return $response;
+        if ($curlError !== CURLE_OK) {
+            error_log("Sentry push failed with curl error ({$curlError}): {$response}");
+            return 500;
+        }
+    
+        if ($httpCode >= 400 || $httpCode === 0) {
+            error_log("Sentry push failed with status code {$httpCode}: {$curlError} ({$response})");
+            return $httpCode ?: 500;
+        }
     }
 
     public function getSupportedTypes(): array

--- a/src/Logger/Adapter/Sentry.php
+++ b/src/Logger/Adapter/Sentry.php
@@ -61,8 +61,6 @@ class Sentry extends Adapter
      *
      * @param  Log  $log
      * @return int
-     *
-     * @throws Exception
      */
     public function push(Log $log): int
     {
@@ -156,7 +154,7 @@ class Sentry extends Adapter
         $error = \curl_error($ch);
 
         if ($response >= 400 || $response === 0) {
-            throw new Exception("Log could not be pushed with status code {$response}: {$result} ({$error})");
+            error_log("Log could not be pushed with status code {$response}: {$result} ({$error})");
         }
 
         \curl_close($ch);

--- a/tests/e2e/Adapter/AppSignalTest.php
+++ b/tests/e2e/Adapter/AppSignalTest.php
@@ -14,5 +14,6 @@ class AppSignalTest extends AdapterBase
         parent::setUp();
         $appSignalKey = \getenv('TEST_APPSIGNAL_KEY');
         $this->adapter = new AppSignal($appSignalKey ? $appSignalKey : '');
+        $this->invalidAdapter = new AppSignal('');
     }
 }

--- a/tests/e2e/Adapter/LogOwlTest.php
+++ b/tests/e2e/Adapter/LogOwlTest.php
@@ -12,6 +12,6 @@ class LogOwlTest extends AdapterBase
         parent::setUp();
         $logOwlKey = \getenv('TEST_LOGOWL_KEY');
         $this->adapter = new LogOwl($logOwlKey ? $logOwlKey : '');
-        $this->invalidAdapter = new LogOwl('abc');
+        $this->invalidAdapter = new LogOwl('abc', 'https://api.invalid.io/logging/');
     }
 }

--- a/tests/e2e/Adapter/LogOwlTest.php
+++ b/tests/e2e/Adapter/LogOwlTest.php
@@ -12,6 +12,6 @@ class LogOwlTest extends AdapterBase
         parent::setUp();
         $logOwlKey = \getenv('TEST_LOGOWL_KEY');
         $this->adapter = new LogOwl($logOwlKey ? $logOwlKey : '');
-        $this->invalidAdapter = new LogOwl('');
+        $this->invalidAdapter = new LogOwl('abc');
     }
 }

--- a/tests/e2e/Adapter/LogOwlTest.php
+++ b/tests/e2e/Adapter/LogOwlTest.php
@@ -12,5 +12,6 @@ class LogOwlTest extends AdapterBase
         parent::setUp();
         $logOwlKey = \getenv('TEST_LOGOWL_KEY');
         $this->adapter = new LogOwl($logOwlKey ? $logOwlKey : '');
+        $this->invalidAdapter = new LogOwl('');
     }
 }

--- a/tests/e2e/Adapter/RaygunTest.php
+++ b/tests/e2e/Adapter/RaygunTest.php
@@ -12,6 +12,7 @@ class RaygunTest extends AdapterBase
         parent::setUp();
         $raygunKey = \getenv('TEST_RAYGUN_KEY');
         $this->adapter = new Raygun($raygunKey ? $raygunKey : '');
+        $this->invalidAdapter = new Raygun('');
         $this->expected = 202;
     }
 }

--- a/tests/e2e/Adapter/SentryTest.php
+++ b/tests/e2e/Adapter/SentryTest.php
@@ -19,5 +19,6 @@ class SentryTest extends AdapterBase
         $url = $scheme.'://'.$host;
 
         $this->adapter = new Sentry($path, $user, $url);
+        $this->invalidAdapter = new Sentry('', '', '');
     }
 }

--- a/tests/e2e/AdapterBase.php
+++ b/tests/e2e/AdapterBase.php
@@ -98,9 +98,9 @@ abstract class AdapterBase extends TestCase
         $logger = new Logger($this->invalidAdapter);
 
         // Should return an error status code without throwing
-        $response = $logger->addLog($this->log);
+        $statusCode = $logger->addLog($this->log);
 
-        // Should return 401, 403, or 500 depending on the service
-        $this->assertContains($response, [401, 403, 500]);
+        // Should return > 400 status code
+        $this->assertGreaterThan(400, $statusCode);
     }
 }

--- a/tests/e2e/AdapterBase.php
+++ b/tests/e2e/AdapterBase.php
@@ -91,6 +91,10 @@ abstract class AdapterBase extends TestCase
 
     public function testAdapterFailure(): void
     {
+        if (empty($this->log) || empty($this->invalidAdapter)) {
+            throw new \Exception('Log or adapter not set');
+        }
+
         $logger = new Logger($this->invalidAdapter);
 
         // Should return an error status code without throwing

--- a/tests/e2e/AdapterBase.php
+++ b/tests/e2e/AdapterBase.php
@@ -14,6 +14,7 @@ abstract class AdapterBase extends TestCase
     protected ?Log $log = null;
 
     protected ?Adapter $adapter = null;
+    protected ?Adapter $invalidAdapter = null;
 
     protected int $expected = 200;
 
@@ -85,5 +86,16 @@ abstract class AdapterBase extends TestCase
         $zeroPercentage = ($zeroCount / count($results)) * 100;
 
         $this->assertGreaterThan(85, $zeroPercentage);
+    }
+
+    public function testAdapterFailure(): void
+    {
+        $logger = new Logger($this->invalidAdapter);
+        
+        // Should return an error status code without throwing
+        $response = $logger->addLog($this->log);
+        
+        // Should return 401, 403, or 500 depending on the service
+        $this->assertContains($response, [401, 403, 500]);
     }
 }

--- a/tests/e2e/AdapterBase.php
+++ b/tests/e2e/AdapterBase.php
@@ -14,6 +14,7 @@ abstract class AdapterBase extends TestCase
     protected ?Log $log = null;
 
     protected ?Adapter $adapter = null;
+
     protected ?Adapter $invalidAdapter = null;
 
     protected int $expected = 200;
@@ -91,10 +92,10 @@ abstract class AdapterBase extends TestCase
     public function testAdapterFailure(): void
     {
         $logger = new Logger($this->invalidAdapter);
-        
+
         // Should return an error status code without throwing
         $response = $logger->addLog($this->log);
-        
+
         // Should return 401, 403, or 500 depending on the service
         $this->assertContains($response, [401, 403, 500]);
     }


### PR DESCRIPTION
Removes throw from each adapter log push.

Instead, calls `error_log` if we encounter a CURL error or a status code >=400

It also return the status code, or if it doesn't have one, 500