### PR TITLE
Remove deprecated curl_close calls

### DIFF
--- a/src/Logger/Adapter/AppSignal.php
+++ b/src/Logger/Adapter/AppSignal.php
@@ -145,7 +145,6 @@ class AppSignal extends Adapter
         $response = curl_exec($ch);
         $httpCode = curl_getinfo($ch, \CURLINFO_HTTP_CODE);
         $curlError = \curl_errno($ch);
-        \curl_close($ch);
 
         if ($curlError !== CURLE_OK || $httpCode === 0) {
             error_log("AppSignal push failed with curl error ({$curlError}): {$response}");

--- a/src/Logger/Adapter/LogOwl.php
+++ b/src/Logger/Adapter/LogOwl.php
@@ -162,7 +162,6 @@ class LogOwl extends Adapter
         $response = curl_exec($ch);
         $httpCode = curl_getinfo($ch, \CURLINFO_HTTP_CODE);
         $curlError = \curl_errno($ch);
-        \curl_close($ch);
 
         if ($curlError !== CURLE_OK || $httpCode === 0) {
             error_log("LogOwl push failed with curl error ({$curlError}): {$response}");

--- a/src/Logger/Adapter/Raygun.php
+++ b/src/Logger/Adapter/Raygun.php
@@ -130,7 +130,6 @@ class Raygun extends Adapter
         $response = curl_exec($ch);
         $httpCode = curl_getinfo($ch, \CURLINFO_HTTP_CODE);
         $curlError = \curl_errno($ch);
-        \curl_close($ch);
 
         if ($curlError !== CURLE_OK || $httpCode === 0) {
             error_log("Raygun push failed with curl error ({$curlError}): {$response}");

--- a/src/Logger/Adapter/Sentry.php
+++ b/src/Logger/Adapter/Sentry.php
@@ -172,7 +172,6 @@ class Sentry extends Adapter
         $response = curl_exec($ch);
         $httpCode = curl_getinfo($ch, \CURLINFO_HTTP_CODE);
         $curlError = \curl_errno($ch);
-        \curl_close($ch);
 
         if ($curlError !== CURLE_OK || $httpCode === 0) {
             error_log("Sentry push failed with curl error ({$curlError}): {$response}");


### PR DESCRIPTION
## What does this PR do?

Removes calls to `curl_close()`. Since PHP 8.0, cURL handles are `CurlHandle` objects and `curl_close()` no longer has an effect; handles are released by object lifetime instead. Removing these calls avoids noisy PHP 8.5 deprecation warnings without changing behavior for supported PHP versions.

## Test Plan

- Ran `php -l` on changed PHP files where applicable.
- Confirmed no `curl_close(...)` calls remain in this repository.

## Related PRs and Issues

N/A

### Have you read the Contributing Guidelines on issues?

Yes.
