### PR TITLE
Fix PHP 8.5 curl_close() deprecation

### DIFF
--- a/src/Logger/Adapter/AppSignal.php
+++ b/src/Logger/Adapter/AppSignal.php
@@ -145,7 +145,6 @@ class AppSignal extends Adapter
         $response = curl_exec($ch);
         $httpCode = curl_getinfo($ch, \CURLINFO_HTTP_CODE);
         $curlError = \curl_errno($ch);
-        \curl_close($ch);
 
         if ($curlError !== CURLE_OK || $httpCode === 0) {
             error_log("AppSignal push failed with curl error ({$curlError}): {$response}");

--- a/src/Logger/Adapter/LogOwl.php
+++ b/src/Logger/Adapter/LogOwl.php
@@ -162,7 +162,6 @@ class LogOwl extends Adapter
         $response = curl_exec($ch);
         $httpCode = curl_getinfo($ch, \CURLINFO_HTTP_CODE);
         $curlError = \curl_errno($ch);
-        \curl_close($ch);
 
         if ($curlError !== CURLE_OK || $httpCode === 0) {
             error_log("LogOwl push failed with curl error ({$curlError}): {$response}");

--- a/src/Logger/Adapter/Raygun.php
+++ b/src/Logger/Adapter/Raygun.php
@@ -130,7 +130,6 @@ class Raygun extends Adapter
         $response = curl_exec($ch);
         $httpCode = curl_getinfo($ch, \CURLINFO_HTTP_CODE);
         $curlError = \curl_errno($ch);
-        \curl_close($ch);
 
         if ($curlError !== CURLE_OK || $httpCode === 0) {
             error_log("Raygun push failed with curl error ({$curlError}): {$response}");

--- a/src/Logger/Adapter/Sentry.php
+++ b/src/Logger/Adapter/Sentry.php
@@ -172,7 +172,6 @@ class Sentry extends Adapter
         $response = curl_exec($ch);
         $httpCode = curl_getinfo($ch, \CURLINFO_HTTP_CODE);
         $curlError = \curl_errno($ch);
-        \curl_close($ch);
 
         if ($curlError !== CURLE_OK || $httpCode === 0) {
             error_log("Sentry push failed with curl error ({$curlError}): {$response}");


### PR DESCRIPTION
## Summary
- Remove the no-op `\curl_close($ch)` calls in all four logger adapters (Sentry, AppSignal, LogOwl, Raygun) that trigger `Deprecated` notices on PHP 8.5.

## Why
`curl_close()` has been a no-op since PHP 8.0 and is now formally deprecated in 8.5. The curl handle is freed when the variable goes out of scope.

## Test plan
- [x] `composer lint` (Pint) — pass
- [x] `composer check` (PHPStan max) — pass on PHP 8.3